### PR TITLE
Allow DDHotKey integration into code which includes WebKit in precompiled header

### DIFF
--- a/DDHotKeyCenter.m
+++ b/DDHotKeyCenter.m
@@ -57,8 +57,9 @@ OSStatus dd_hotKeyHandler(EventHandlerCallRef nextHandler, EventRef theEvent, vo
 - (BOOL)isEqual:(id)object {
     BOOL equal = NO;
     if ([object isKindOfClass:[DDHotKey class]]) {
-        equal = ([object keyCode] == [self keyCode]);
-        equal &= ([object modifierFlags] == [self modifierFlags]);
+		DDHotKey* other = (DDHotKey*)object;
+        equal = ([other keyCode] == [self keyCode]);
+        equal &= ([other modifierFlags] == [self modifierFlags]);
     }
     return equal;
 }


### PR DESCRIPTION
Fixed compiler "error: multiple methods named 'keyCode' found with mismatched result, parameter type or attributes" when using WebKit in precompiled header

The possible methods named 'keyCode' are:
    NSEvent: -(unsigned short) keyCode
    DDHotKey: @property (nonatomic, setter = _setKeyCode:) unsigned short keyCode
    DOMUIEvent : @property(readonly) int keyCode

DOMUIEvent is int whereas DDHotKey and NSEvent is unsigned short
